### PR TITLE
Resolve promise after large file upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,3 +118,11 @@
 </script>
 
 ```
+
+## Handling Partial Upload Success
+
+In scenarios where large files are uploaded in parts, there might be cases where not all parts are successfully uploaded. To address this, a new state `PARTIAL_SUCCESS` has been introduced. This state indicates that the file has been partially uploaded, with some chunks failing to upload even after exhausting all retry attempts.
+
+When a file's uploading status is set to `PARTIAL_SUCCESS`, it implies that the file is not fully uploaded, and manual intervention might be required to either retry the failed parts or handle the partially uploaded file according to the application's logic.
+
+This feature ensures that the promise will always trigger resolve() after a large file upload attempt, providing a more reliable and predictable upload process for large files.

--- a/src/utils/upload.js
+++ b/src/utils/upload.js
@@ -20,6 +20,11 @@ const UPLOADING = 1
  * @type {number}
  */
 const SUCCESS = 2
+/**
+ * 部分上传成功
+ * @type {number}
+ */
+const PARTIAL_SUCCESS = 3
 
 export default class Uploader {
   constructor(options) {
@@ -260,6 +265,8 @@ export default class Uploader {
     }
     if (Object.keys(this.file.chunk.xhr).length === chunk.total) {
       this.file.uploading = SUCCESS
+    } else if (this._filterChunkList(ERROR).length > 0) {
+      this.file.uploading = PARTIAL_SUCCESS
     }
   }
 
@@ -323,11 +330,15 @@ export default class Uploader {
             let num = this._filterChunkList(SUCCESS).length
             if (num === this.chunks.length) {
               this.file.uploadPercent = 100
+              resolve(this.file)
               return
             }
             this.file.uploadPercent = Math.floor(100 / this.chunks.length * num)
             recursive()
-          }).catch(() => recursive())
+          }).catch(() => {
+            resolve(this.file)
+            recursive()
+          })
         }
       }
       recursive()


### PR DESCRIPTION
closed #1

Introduces handling for partial success in chunked file uploads and updates documentation to reflect this new feature.

- Adds a new `PARTIAL_SUCCESS` constant to represent a state where a file is partially uploaded due to some chunks failing to upload.
- Modifies the `_setFileUploadResult` method to set the file's `uploading` status to `PARTIAL_SUCCESS` when not all chunks are successfully uploaded.
- Ensures the promise in `_sendChunkQueue` resolves even if some chunks fail to upload, marking the upload as partially successful.
- Updates the README.md to include documentation on the new `PARTIAL_SUCCESS` state and its implications for large file uploads.

